### PR TITLE
Make path to xml files configurable via X11_BASE_RULES_XML and X11_EXTRA_RULES_XML environment variables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,14 +88,24 @@ pub fn get_keyboard_layouts(path: &str) -> io::Result<KeyboardLayouts> {
         .map_err(|why| io::Error::new(io::ErrorKind::InvalidData, format!("{}", why)))
 }
 
-/// Fetches a list of keyboard layouts from `/usr/share/X11/xkb/rules/base.xml`.
+/// Fetches a list of keyboard layouts from `/usr/share/X11/xkb/rules/base.xml` or the file defined in the X11_BASE_RULES_XML environment variable.
 pub fn keyboard_layouts() -> io::Result<KeyboardLayouts> {
-    get_keyboard_layouts(X11_BASE_RULES)
+    if let Ok(x11_base_rules_xml) = std::env::var("X11_BASE_RULES_XML") {
+        get_keyboard_layouts(&x11_base_rules_xml)
+    }
+    else {
+        get_keyboard_layouts(X11_BASE_RULES)
+    }
 }
 
-/// Fetches a list of keyboard layouts from `/usr/share/X11/xkb/rules/base.extras.xml`.
+/// Fetches a list of keyboard layouts from `/usr/share/X11/xkb/rules/base.extras.xml` or the file defined in the X11_EXTRA_RULES_XML environment variable.
 pub fn extra_keyboard_layouts() -> io::Result<KeyboardLayouts> {
-    get_keyboard_layouts(X11_EXTRAS_RULES)
+    if let Ok(x11_extra_rules_xml) = std::env::var("X11_EXTRA_RULES_XML") {
+        get_keyboard_layouts(&x11_extra_rules_xml)
+    }
+    else {
+        get_keyboard_layouts(X11_EXTRAS_RULES)
+    }
 }
 
 /// Fetches a list of keyboard layouts from `/usr/share/X11/xkb/rules/base.xml` and


### PR DESCRIPTION
This crate currently uses a hard coded path to locate the base.xml file. While this is sufficient for many distributions, it is not compatible with distributions that do not follow FHS (like NixOS for example).

This patch adds the option to set the base.xml path via the X11_BASE_RULES_XML environment variable.
I derived the name of the variable from the constant used in the code, but we could change it if necessary. 

The inclusion of this patch would simplify packaging cosmic-settings and cosmic-greeter (and possibly more) for NixOS.