### PR TITLE
feat: support user-defined xkb layouts

### DIFF
--- a/examples/layouts.rs
+++ b/examples/layouts.rs
@@ -11,12 +11,12 @@ fn main() {
         }
         count += 1;
     }
-
     println!("Total layouts without extra sources: {}", count);
 
-    count = 0;
-    let all_layouts = xkb_data::all_keyboard_layouts().unwrap();
-    for layout in all_layouts.layouts() {
+    println!("user-provided layouts");
+    let layouts = xkb_data::user_keyboard_layouts().unwrap();
+    let mut count = 0;
+    for layout in layouts.layouts() {
         println!("  {}: {}", layout.name(), layout.description());
         if let Some(variants) = layout.variants() {
             for variant in variants {
@@ -25,5 +25,12 @@ fn main() {
         }
         count += 1;
     }
-    println!("Total layouts including extra sources: {}", count);
+    println!("Total user-provided layouts: {}", count);
+
+    count = 0;
+    let all_layouts = xkb_data::all_keyboard_layouts().unwrap();
+    for layout in all_layouts.layouts() {
+        count += 1;
+    }
+    println!("Total layouts including extra sources and user layouts: {}", count);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,24 @@ use serde::Deserialize;
 use serde_xml_rs as xml;
 use std::fs::File;
 use std::io::{self, BufReader};
+use std::path::PathBuf;
 
+// As per XKB official configuration guide, on Linux we use `evdev.xml`
+#[cfg(target_os = "linux")]
+const RULES_FILE: &str = "evdev.xml";
+#[cfg(target_os = "linux")]
+const X11_BASE_RULES: &str = "/usr/share/X11/xkb/rules/evdev.xml";
+#[cfg(target_os = "linux")]
+const X11_EXTRAS_RULES: &str = "/usr/share/X11/xkb/rules/evdev.extras.xml";
+// when not on Linux, we use `base.xml`
+#[cfg(not(target_os = "linux"))]
+const RULES_FILE: &str = "base.xml";
+#[cfg(not(target_os = "linux"))]
 const X11_BASE_RULES: &str = "/usr/share/X11/xkb/rules/base.xml";
+#[cfg(not(target_os = "linux"))]
 const X11_EXTRAS_RULES: &str = "/usr/share/X11/xkb/rules/base.extras.xml";
 
-/// A list of keyboard layouts parsed from `/usr/share/X11/xkb/rules/base.xml`.
+/// A list of keyboard layouts parsed from X11_BASE_RULES.
 #[derive(Debug, Deserialize, Clone)]
 pub struct KeyboardLayouts {
     #[serde(rename = "layoutList")]
@@ -88,7 +101,7 @@ pub fn get_keyboard_layouts(path: &str) -> io::Result<KeyboardLayouts> {
         .map_err(|why| io::Error::new(io::ErrorKind::InvalidData, format!("{}", why)))
 }
 
-/// Fetches a list of keyboard layouts from `/usr/share/X11/xkb/rules/base.xml` or the file defined in the X11_BASE_RULES_XML environment variable.
+/// Fetches a list of keyboard layouts from the X11_BASE_RULES const or the file defined in the X11_BASE_RULES_XML environment variable.
 pub fn keyboard_layouts() -> io::Result<KeyboardLayouts> {
     if let Ok(x11_base_rules_xml) = std::env::var("X11_BASE_RULES_XML") {
         get_keyboard_layouts(&x11_base_rules_xml)
@@ -98,7 +111,7 @@ pub fn keyboard_layouts() -> io::Result<KeyboardLayouts> {
     }
 }
 
-/// Fetches a list of keyboard layouts from `/usr/share/X11/xkb/rules/base.extras.xml` or the file defined in the X11_EXTRA_RULES_XML environment variable.
+/// Fetches a list of keyboard layouts from the X11_EXTRAS_RULES const or the file defined in the X11_EXTRA_RULES_XML environment variable.
 pub fn extra_keyboard_layouts() -> io::Result<KeyboardLayouts> {
     if let Ok(x11_extra_rules_xml) = std::env::var("X11_EXTRA_RULES_XML") {
         get_keyboard_layouts(&x11_extra_rules_xml)
@@ -108,17 +121,78 @@ pub fn extra_keyboard_layouts() -> io::Result<KeyboardLayouts> {
     }
 }
 
-/// Fetches a list of keyboard layouts from `/usr/share/X11/xkb/rules/base.xml` and
-/// extends them with the list of keyboard layouts from `/usr/share/X11/xkb/rules/base.extras.xml`.
-pub fn all_keyboard_layouts() -> io::Result<KeyboardLayouts> {
-    let base_rules = keyboard_layouts();
-    let extras_rules = extra_keyboard_layouts();
+/// Fetches user-specific keyboard layouts from XDG config paths.
+/// On Linux, looks for `evdev.xml`, on other systems looks for `base.xml`.
+/// Returns all layouts found from these paths:
+/// 1. `$XDG_CONFIG_HOME/xkb/rules/` (defaults to `$HOME/.config/xkb/rules/`)
+/// 2. `$HOME/.xkb/rules/`
+/// Returns empty layouts if no files are found.
+pub fn user_keyboard_layouts() -> io::Result<KeyboardLayouts> {
+    let paths = user_xkb_rules_paths();
 
-    match (base_rules, extras_rules,) {
-        (Ok(base_rules), Ok(extras_rules)) => return Ok(merge_rules(base_rules, extras_rules)),
-        (Err(why), _) => return Err(io::Error::new(io::ErrorKind::InvalidData, format!("{}", why))),
-        (_, Err(why)) => return Err(io::Error::new(io::ErrorKind::InvalidData, format!("{}", why))),
+    let layout_lists: Vec<LayoutList> = paths
+        .into_iter()
+        .filter_map(|path| get_keyboard_layouts(path.to_string_lossy().as_ref()).ok())
+        .map(|layouts| layouts.layout_list)
+        .collect();
+
+    Ok(KeyboardLayouts {
+        layout_list: concat_layout_lists(layout_lists),
+    })
+}
+
+/// Returns the list of user XKB rules paths to check for a given rules file.
+fn user_xkb_rules_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    // Defaults to $HOME/.config/xkb/rules/ if XDG_CONFIG_HOME is not set
+    if let Ok(xdg_config_home) = std::env::var("XDG_CONFIG_HOME") {
+        let mut path = PathBuf::from(xdg_config_home);
+        path.push("xkb/rules");
+        path.push(RULES_FILE);
+        if path.exists() {
+            paths.push(path);
+        }
+    } else if let Ok(home) = std::env::var("HOME") {
+        let mut path = PathBuf::from(home);
+        path.push(".config/xkb/rules");
+        path.push(RULES_FILE);
+        if path.exists() {
+            paths.push(path);
+        }
     }
+
+    // Second priority: $HOME/.xkb/rules/
+    if let Ok(home) = std::env::var("HOME") {
+        let mut path = PathBuf::from(home);
+        path.push(".xkb/rules");
+        path.push(RULES_FILE);
+        if path.exists() {
+            paths.push(path);
+        }
+    }
+
+    paths
+}
+
+/// Fetches a list of keyboard layouts from the system rules files and user config paths,
+/// merging them together.
+pub fn all_keyboard_layouts() -> io::Result<KeyboardLayouts> {
+    let base_rules = keyboard_layouts()?;
+    let extras_rules = extra_keyboard_layouts()?;
+    let user_rules = user_keyboard_layouts().unwrap_or(KeyboardLayouts {
+        layout_list: LayoutList { layout: vec![] },
+    });
+
+    let layout_lists = vec![
+        base_rules.layout_list,
+        extras_rules.layout_list,
+        user_rules.layout_list,
+    ];
+
+    Ok(KeyboardLayouts {
+        layout_list: concat_layout_lists(layout_lists),
+    })
 }
 
 fn merge_rules(base: KeyboardLayouts, extras: KeyboardLayouts) -> KeyboardLayouts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,14 @@ pub struct KeyboardLayouts {
 
 impl KeyboardLayouts {
     /// Fetch the layouts from the layout list.
-    pub fn layouts(&self) -> &[KeyboardLayout] { &self.layout_list.layout }
+    pub fn layouts(&self) -> &[KeyboardLayout] {
+        &self.layout_list.layout
+    }
 
     /// Fetch the layouts from the layout list.
-    pub fn layouts_mut(&mut self) -> &mut [KeyboardLayout] { &mut self.layout_list.layout }
+    pub fn layouts_mut(&mut self) -> &mut [KeyboardLayout] {
+        &mut self.layout_list.layout
+    }
 }
 
 /// A list of keyboard layouts.
@@ -47,17 +51,21 @@ pub struct LayoutList {
 #[derive(Debug, Deserialize, Clone)]
 pub struct KeyboardLayout {
     #[serde(rename = "configItem")]
-    pub config_item:  ConfigItem,
+    pub config_item: ConfigItem,
     #[serde(rename = "variantList")]
     pub variant_list: Option<VariantList>,
 }
 
 impl KeyboardLayout {
     /// Fetches the name of the keyboard layout.
-    pub fn name(&self) -> &str { &self.config_item.name }
+    pub fn name(&self) -> &str {
+        &self.config_item.name
+    }
 
     /// Fetches a description of the layout.
-    pub fn description(&self) -> &str { &self.config_item.description }
+    pub fn description(&self) -> &str {
+        &self.config_item.description
+    }
 
     /// Fetches a list of possible layout variants.
     pub fn variants(&self) -> Option<&Vec<KeyboardVariant>> {
@@ -68,10 +76,10 @@ impl KeyboardLayout {
 /// Contains the name and description of a keyboard layout.
 #[derive(Debug, Deserialize, Clone)]
 pub struct ConfigItem {
-    pub name:              String,
+    pub name: String,
     #[serde(rename = "shortDescription")]
     pub short_description: Option<String>,
-    pub description:       String,
+    pub description: String,
 }
 
 /// A list of possible variants of a keyboard layout.
@@ -89,10 +97,14 @@ pub struct KeyboardVariant {
 
 impl KeyboardVariant {
     /// The name of this variant of a keybaord layout.
-    pub fn name(&self) -> &str { &self.config_item.name }
+    pub fn name(&self) -> &str {
+        &self.config_item.name
+    }
 
     /// A description of this variant of a keyboard layout.
-    pub fn description(&self) -> &str { &self.config_item.description }
+    pub fn description(&self) -> &str {
+        &self.config_item.description
+    }
 }
 
 /// Fetches a list of keyboard layouts from a path.
@@ -105,8 +117,7 @@ pub fn get_keyboard_layouts(path: &str) -> io::Result<KeyboardLayouts> {
 pub fn keyboard_layouts() -> io::Result<KeyboardLayouts> {
     if let Ok(x11_base_rules_xml) = std::env::var("X11_BASE_RULES_XML") {
         get_keyboard_layouts(&x11_base_rules_xml)
-    }
-    else {
+    } else {
         get_keyboard_layouts(X11_BASE_RULES)
     }
 }
@@ -115,8 +126,7 @@ pub fn keyboard_layouts() -> io::Result<KeyboardLayouts> {
 pub fn extra_keyboard_layouts() -> io::Result<KeyboardLayouts> {
     if let Ok(x11_extra_rules_xml) = std::env::var("X11_EXTRA_RULES_XML") {
         get_keyboard_layouts(&x11_extra_rules_xml)
-    }
-    else {
+    } else {
         get_keyboard_layouts(X11_EXTRAS_RULES)
     }
 }
@@ -197,7 +207,7 @@ pub fn all_keyboard_layouts() -> io::Result<KeyboardLayouts> {
 
 fn merge_rules(base: KeyboardLayouts, extras: KeyboardLayouts) -> KeyboardLayouts {
     KeyboardLayouts {
-        layout_list: concat_layout_lists(vec![base.layout_list, extras.layout_list])
+        layout_list: concat_layout_lists(vec![base.layout_list, extras.layout_list]),
     }
 }
 
@@ -206,5 +216,7 @@ fn concat_layout_lists(layouts: Vec<LayoutList>) -> LayoutList {
     for layout_list in layouts.into_iter() {
         new_layouts.extend(layout_list.layout);
     }
-    return LayoutList { layout: new_layouts }
+    return LayoutList {
+        layout: new_layouts,
+    };
 }


### PR DESCRIPTION
This PR allows users to add custom layouts as per the [xkbcommon user-configuration page](https://xkbcommon.org/doc/current/user-configuration.html), by adding a custom symbol file in `$XDG_CONFIG_HOME/xkb/symbols/`, or more commonly in `$HOME/.config/xkb/` when the `$XDG_CONFIG_HOME` env is not defined.

E.g. adding the banana layout as the file `$HOME/.config/xkb/symbols/banana`:
```
// Like a US layout but swap the top row so numbers are on Shift
default partial alphanumeric_keys
xkb_symbols "basic" {
    include "us(basic)"
    name[Group1]= "Banana (US)";
 
    key <AE01> { [ exclam,          1]     };
    key <AE02> { [ at,              2]     };
    key <AE03> { [ numbersign,      3]     };
    key <AE04> { [ dollar,          4]     };
    key <AE05> { [ percent,         5]     };
    key <AE06> { [ asciicircum,     6]     };
    key <AE07> { [ ampersand,       7]     };
    key <AE08> { [ asterisk,        8]     };
    key <AE09> { [ parenleft,       9]     };
    key <AE10> { [ parenright,      0]     };
    key <AE11> { [ underscore,      minus] };
    key <AE12> { [ plus,            equal] };
};
 
// Same as banana but map the euro sign to the 5 key
partial alphanumeric_keys
xkb_symbols "orange" {
    include "banana(basic)"
    name[Group1] = "Banana (Eurosign on 5)";
    include "eurosign(5)"
};
```

However given that this xkb-data crate gets the data from the rule files, there is the extra constraint of having to define a new entry in a custom `$XDG_CONFIG_HOME/xkb/rules/evdev.xml` file, as per the [discoverable layout entry](https://xkbcommon.org/doc/current/user-configuration.html#discoverable-layouts) of xkbcommon docs.

Content of $XDG_CONFIG_HOME/xkb/rules/evdev.xml:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE xkbConfigRegistry SYSTEM "xkb.dtd">
<xkbConfigRegistry version="1.1">
  <layoutList>
    <!-- Declare a new layout and its variants -->
    <layout>
      <!-- Default variant: `default … xkb_symbols "…"` -->
      <configItem>
        <!-- File name of $XDG_CONFIG_HOME/xkb/symbols/banana -->
        <name>banana</name>
        <shortDescription>ban</shortDescription>
        <!-- Label: use the value of `name[Group1]` -->
        <description>Banana (US)</description>
      </configItem>
      <!-- Other variants -->
      <variantList>
        <variant>
          <configItem>
            <!-- Section name in $XDG_CONFIG_HOME/xkb/symbols/banana -->
            <name>orange</name>
            <shortDescription>or</shortDescription>
            <!-- Label: use the value of `name[Group1]` -->
            <description>Banana (Eurosign on 5)</description>
          </configItem>
        </variant>
      </variantList>
    </layout>
  </layoutList>
</xkbConfigRegistry>
```

Finally this PR does another 2 little cleanups:
- It runs `cargo fmt` on the code
- It makes it so that it correctly uses the `evdev.xml` file as a rule file on Linux rather than the `base.xml` file which is meant for non-Linux system [as per the XKB config guide](https://www.x.org/releases/X11R7.6/doc/xorg-docs/input/XKB-Config.html#id2521360).  (`evdev` is the current Linux input system and didn't exist back when XKB was created.)

Happy to revert the `cargo fmt` change and submit it in a separate PR if it's easier for you to review @mmstick.